### PR TITLE
Add Import functionality for .csv files

### DIFF
--- a/import/import.csv
+++ b/import/import.csv
@@ -1,0 +1,4 @@
+﻿Name,Number,Email,Address,Tag
+Tom,91234812,hi@mail.com,NUS,cool
+John ,91232345,john@john.com,NTU,notcool
+Ben,83478596,ben@mail.com,NA,

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -1,0 +1,149 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.AddressBookParser;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.*;
+
+import static java.util.Objects.requireNonNull;
+
+public class ImportCommand extends Command{
+
+    public static final String COMMAND_WORD = "import";
+    public static final String MESSAGE_SUCCESS = "Contacts from csv have been added!";
+    public static final String MESSAGE_FILE_NOT_FOUND = "File could not be found! Check import.csv exists at ./import";
+    public static final String MESSAGE_FIELDS_FORMAT_ERROR = "An error occurred while parsing the csv! " +
+            "Check the fields!";
+    public static final String MESSAGE_VALUES_FORMAT_ERROR = "An error occurred while parsing the csv! " +
+            "Check the values!";
+    public static final String MESSAGE_PARSE_FORMAT_ERROR = "An error occurred while adding persons to the csv! " +
+            "The values in the csv are converted to add command format\n" +
+            "Make sure the values match the correct format for the add command!\n" +
+            "The error with the add command occurred as follows:\n";
+    public static final String FILE_PATH = "./import/import.csv"; // Path to the .csv file to import
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Updates the Address book with contacts from the "
+            + "csv file found at path: " + FILE_PATH
+            + "Parameters: None "
+            + "Example: " + COMMAND_WORD;
+
+    private final List<String> FIELDS = List.of(
+            "NAME", "NUMBER", "EMAIL", "ADDRESS", "TAG"
+    ); // TO hold the fields present in the csv
+    private final int NUMBER_OF_FIELDS = FIELDS.size();
+    private final Map<String, String> PREFIX_MAP = Map.of(
+            "NAME", "n/",
+            "NUMBER", "p/",
+            "EMAIL", "e/",
+            "ADDRESS", "a/",
+            "TAG", "t/"
+    ); // To format the data in the csv to command format
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException{
+        requireNonNull(model);
+
+        List<String> personsToAdd = new ArrayList<>(); // To hold the person data from the csv
+
+        try { // parse the csv file at the path w scanner
+            parse(personsToAdd);
+            checkFields(personsToAdd.get(0));
+            personsToAdd.remove(0); // remove the fields
+            addPersons(personsToAdd, model);
+
+        } catch (FileNotFoundException e) {
+            throw new CommandException(MESSAGE_FILE_NOT_FOUND);
+        } catch (IndexOutOfBoundsException e) {
+            throw new CommandException(MESSAGE_VALUES_FORMAT_ERROR);
+        } catch (ParseException e) {
+            throw new CommandException(MESSAGE_PARSE_FORMAT_ERROR + e.getMessage());
+        }
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    /**
+     * Parses the data in the csv into the given list
+     *
+     * @param list to hold the parsed values in String format
+     */
+    private void parse(List<String> list) throws FileNotFoundException, IndexOutOfBoundsException {
+        StringBuilder curr_row = new StringBuilder(); // To hold the current row data
+        Scanner sc = new Scanner(new File(FILE_PATH));
+        sc.useDelimiter(",|\r?\n");
+        int count = 0; // holds an idx to keep track of the current field
+
+        while (sc.hasNext()) {
+            String next = sc.next();
+
+            if (!next.isEmpty()) { // append the field in the correct format if present
+                String formatted = formatFieldValue(next, FIELDS.get(count));
+                curr_row.append(formatted);
+            }
+            count += 1;
+            if (count == NUMBER_OF_FIELDS) { // add the person data to the list once parsed
+                curr_row.deleteCharAt(curr_row.length() - 1); // remove trailing " "
+                list.add(curr_row.toString());
+                curr_row = new StringBuilder();
+                count = 0;
+            }
+        }
+        sc.close();
+    }
+
+    /**
+     * Formats the given data field into proper command format
+     *
+     * @param fieldValue the value to be formatted
+     * @param field the field the value belongs to
+     * @return the given field value formatted into command format
+     */
+    private String formatFieldValue(String fieldValue, String field) {
+        final String UTF8_BOM = "\uFEFF";
+        if (fieldValue.startsWith(UTF8_BOM)) { // to remove extra potential characters added due to format
+            fieldValue = fieldValue.substring(1);
+        }
+        String prefix = PREFIX_MAP.get(field);
+        return  prefix + fieldValue + " ";
+    }
+
+    /**
+     * Returns True if given String matches the number and order of fields specified in FIELDS
+     *
+     * @param fieldString String parsed from the first row of the csv file
+     * @return boolean for match between fieldString and FIELDS
+     */
+    private void checkFields(String fieldString) throws CommandException {
+        StringBuilder fields = new StringBuilder();
+        for (String field: FIELDS) {
+            fields.append(PREFIX_MAP.get(field));
+            fields.append(field).append(" ");
+        }
+        fields.deleteCharAt(fields.length() - 1); // adjust for extra " "
+        if (!fieldString.equalsIgnoreCase(fields.toString())) {
+            throw new CommandException(MESSAGE_FIELDS_FORMAT_ERROR);
+        };
+    }
+
+    /**
+     * Adds the person data from the list to the addressbook
+     * Simulates the work of AddressBookParser
+     *
+     * @param personData the data parsed from the csv in list format
+     * @param model reference to the model to add the data into
+     */
+    private void addPersons(List<String> personData, Model model) throws ParseException, CommandException {
+        AddressBookParser addressBookParser = new AddressBookParser();
+        // access model and add people into address book
+        for (String person : personData) {
+            String commandText = "add " + person;
+            Command command = addressBookParser.parseCommand(commandText);
+            CommandResult commandResult = command.execute(model);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -1,29 +1,35 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.util.*;
-
-import static java.util.Objects.requireNonNull;
-
-public class ImportCommand extends Command{
+/**
+ * Imports contacts from csv
+ */
+public class ImportCommand extends Command {
 
     public static final String COMMAND_WORD = "import";
     public static final String MESSAGE_SUCCESS = "Contacts from csv have been added!";
     public static final String MESSAGE_FILE_NOT_FOUND = "File could not be found! Check import.csv exists at ./import";
-    public static final String MESSAGE_FIELDS_FORMAT_ERROR = "An error occurred while parsing the csv! " +
-            "Check the fields!";
-    public static final String MESSAGE_VALUES_FORMAT_ERROR = "An error occurred while parsing the csv! " +
-            "Check the values!";
-    public static final String MESSAGE_PARSE_FORMAT_ERROR = "An error occurred while adding persons to the csv! " +
-            "The values in the csv are converted to add command format\n" +
-            "Make sure the values match the correct format for the add command!\n" +
-            "The error with the add command occurred as follows:\n";
+    public static final String MESSAGE_FIELDS_FORMAT_ERROR = "An error occurred while parsing the csv! "
+            + "Check the fields!";
+    public static final String MESSAGE_VALUES_FORMAT_ERROR = "An error occurred while parsing the csv! "
+            + "Check the values!";
+    public static final String MESSAGE_PARSE_FORMAT_ERROR = "An error occurred while adding persons to the csv! "
+            + "The values in the csv are converted to add command format\n"
+            + "Make sure the values match the correct format for the add command!\n"
+            + "The error with the add command occurred as follows:\n";
     public static final String FILE_PATH = "./import/import.csv"; // Path to the .csv file to import
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
@@ -32,11 +38,11 @@ public class ImportCommand extends Command{
             + "Parameters: None "
             + "Example: " + COMMAND_WORD;
 
-    private final List<String> FIELDS = List.of(
+    private static final List<String> FIELDS = List.of(
             "NAME", "NUMBER", "EMAIL", "ADDRESS", "TAG"
     ); // TO hold the fields present in the csv
-    private final int NUMBER_OF_FIELDS = FIELDS.size();
-    private final Map<String, String> PREFIX_MAP = Map.of(
+    private static final int NUMBER_OF_FIELDS = FIELDS.size();
+    private static final Map<String, String> PREFIX_MAP = Map.of(
             "NAME", "n/",
             "NUMBER", "p/",
             "EMAIL", "e/",
@@ -45,7 +51,7 @@ public class ImportCommand extends Command{
     ); // To format the data in the csv to command format
 
     @Override
-    public CommandResult execute(Model model) throws CommandException{
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
         List<String> personsToAdd = new ArrayList<>(); // To hold the person data from the csv
@@ -73,7 +79,7 @@ public class ImportCommand extends Command{
      * @param list to hold the parsed values in String format
      */
     private void parse(List<String> list) throws FileNotFoundException, IndexOutOfBoundsException {
-        StringBuilder curr_row = new StringBuilder(); // To hold the current row data
+        StringBuilder currRow = new StringBuilder(); // To hold the current row data
         Scanner sc = new Scanner(new File(FILE_PATH));
         sc.useDelimiter(",|\r?\n");
         int count = 0; // holds an idx to keep track of the current field
@@ -83,13 +89,13 @@ public class ImportCommand extends Command{
 
             if (!next.isEmpty()) { // append the field in the correct format if present
                 String formatted = formatFieldValue(next, FIELDS.get(count));
-                curr_row.append(formatted);
+                currRow.append(formatted);
             }
             count += 1;
             if (count == NUMBER_OF_FIELDS) { // add the person data to the list once parsed
-                curr_row.deleteCharAt(curr_row.length() - 1); // remove trailing " "
-                list.add(curr_row.toString());
-                curr_row = new StringBuilder();
+                currRow.deleteCharAt(currRow.length() - 1); // remove trailing " "
+                list.add(currRow.toString());
+                currRow = new StringBuilder();
                 count = 0;
             }
         }
@@ -104,19 +110,18 @@ public class ImportCommand extends Command{
      * @return the given field value formatted into command format
      */
     private String formatFieldValue(String fieldValue, String field) {
-        final String UTF8_BOM = "\uFEFF";
-        if (fieldValue.startsWith(UTF8_BOM)) { // to remove extra potential characters added due to format
+        final String rmvChar = "\uFEFF";
+        if (fieldValue.startsWith(rmvChar)) { // to remove extra potential characters added due to format
             fieldValue = fieldValue.substring(1);
         }
         String prefix = PREFIX_MAP.get(field);
-        return  prefix + fieldValue + " ";
+        return prefix + fieldValue + " ";
     }
 
     /**
      * Returns True if given String matches the number and order of fields specified in FIELDS
      *
      * @param fieldString String parsed from the first row of the csv file
-     * @return boolean for match between fieldString and FIELDS
      */
     private void checkFields(String fieldString) throws CommandException {
         StringBuilder fields = new StringBuilder();
@@ -127,7 +132,7 @@ public class ImportCommand extends Command{
         fields.deleteCharAt(fields.length() - 1); // adjust for extra " "
         if (!fieldString.equalsIgnoreCase(fields.toString())) {
             throw new CommandException(MESSAGE_FIELDS_FORMAT_ERROR);
-        };
+        }
     }
 
     /**
@@ -143,7 +148,7 @@ public class ImportCommand extends Command{
         for (String person : personData) {
             String commandText = "add " + person;
             Command command = addressBookParser.parseCommand(commandText);
-            CommandResult commandResult = command.execute(model);
+            command.execute(model);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -16,8 +16,8 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ImportCommand;
+import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ImportCommand.COMMAND_WORD:
+            return new ImportCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -1,0 +1,17 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.ImportCommand.MESSAGE_SUCCESS;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ImportCommand.
+ */
+public class ImportCommandTest {
+
+}

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -1,14 +1,5 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.ImportCommand.MESSAGE_SUCCESS;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
-import org.junit.jupiter.api.Test;
-
-import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
-
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ImportCommand.
  */


### PR DESCRIPTION
Addresses #6 

The import function imports contacts from the file import.csv found in directory ./import

The format of the first line of the csv should be:
NAME | NUMBER | EMAIL | ADDRESS | TAG
with no spacing. The titles are non-caps sensitive

The format of each subsequent line should be follow the appropriate add command format.
There should be no blank lines, and no conflicts with the existing addressbook
